### PR TITLE
Fix access violation with OffFilt.dll

### DIFF
--- a/IFilterTextReader/NativeMethods.cs
+++ b/IFilterTextReader/NativeMethods.cs
@@ -811,7 +811,7 @@ namespace IFilterTextReader
             /// is the first call to the GetChunk method, and returns a description of the current chunk. 
             /// </summary>
             [PreserveSig]
-            IFilterReturnCode GetChunk(out STAT_CHUNK pStat);
+            IFilterReturnCode GetChunk(IntPtr pStat);
 
             /// <summary>
             /// The IFilter::GetText method retrieves text (text-type properties) from the current chunk, 


### PR DESCRIPTION
Fixes #41.

The Office DOC/XLS/PPT Filter distributed with Windows 10 requires the
buffer passed to GetChunk to be kept alive at the same memory location
for the duration of processing the chunk. It saves the pointer in an
internal structure and later tries to access it from the GetValue
method. In the rare case where the STAT_CHUNK structure in the managed
memory was moved by the garbage collector, or possibly due to
P/Invoke marshalling if the structure is not blittable, the memory
would become invalid and the filter would later access invalid memory
location and cause access violations.