### PR TITLE
Provide more user control over character cleanup

### DIFF
--- a/IFilterTextReader/FilterReader.cs
+++ b/IFilterTextReader/FilterReader.cs
@@ -144,6 +144,13 @@ namespace IFilterTextReader
         private bool _carriageReturnFound;
 
         /// <summary>
+        /// Indicates when true (default) that certain characters should be translated to likely ASCII characters.
+        /// </summary>
+        public bool DoCleanUpCharacters { get; set; } = true;
+
+        public string WordBreakSeparator { get; set; } = "-";
+
+        /// <summary>
         /// Collection of metadata properties extracted from file
         /// </summary>
         public readonly Dictionary<string, List<object>> MetaDataProperties = new Dictionary<string, List<object>>();
@@ -570,8 +577,12 @@ namespace IFilterTextReader
                             case NativeMethods.IFilterReturnCode.FILTER_S_LAST_TEXT:
 
                                 textRead = true;
+
                                 // Remove junk from the buffer
-                                CleanUpCharacters(textLength, textBuffer);
+                                if (DoCleanUpCharacters)
+                                {
+                                    CleanUpCharacters(textLength, textBuffer);
+                                }
 
                                 // Check the break type
                                 switch (_chunk.breakType)
@@ -581,7 +592,7 @@ namespace IFilterTextReader
                                         break;
 
                                     case NativeMethods.CHUNK_BREAKTYPE.CHUNK_EOW:
-                                        breakChar = "-";
+                                        breakChar = WordBreakSeparator;
                                         break;
 
                                     case NativeMethods.CHUNK_BREAKTYPE.CHUNK_EOC:


### PR DESCRIPTION
Hi! I'm finding that with the legal documents I'm reading, the "cleanup" routine is removing characters I actually need (section symbols, degrees, etc.), and it may also be applying "-" after spurious "word breaks" coming from the legacy Word reader.

This PR suggests two new fields for the `FilterReader` class to provide the caller with more control over these substitutions. This would be a non-breaking change, since it defaults to the previous behavior.

Thanks!