### PR TITLE
Fixed memory and resource leaks. Added .NET Framework 4.7 target.

### DIFF
--- a/IFilterTextReader/IFilterTextReader.csproj
+++ b/IFilterTextReader/IFilterTextReader.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net47</TargetFrameworks>
     <AssemblyVersion>1.7.8.0</AssemblyVersion>
     <FileVersion>1.7.8.0</FileVersion>
     <Version>1.7.8</Version>

--- a/IFilterTextReader/IStreamWrapper.cs
+++ b/IFilterTextReader/IStreamWrapper.cs
@@ -202,10 +202,10 @@ namespace IFilterTextReader
         /// </summary>
         /// <param name="pstatstg"></param>
         /// <param name="grfStatFlag"></param>
-        public void Stat(out STATSTG pstatstg, int grfStatFlag)
+        public void Stat(out System.Runtime.InteropServices.ComTypes.STATSTG pstatstg, int grfStatFlag)
         {
             // IStreamWrapper wants the length
-            var tempStatstg = new STATSTG {cbSize = _stream.Length};
+            var tempStatstg = new System.Runtime.InteropServices.ComTypes.STATSTG {cbSize = _stream.Length};
             pstatstg = tempStatstg;
         }
         #endregion

--- a/IFilterTextReader/Job.cs
+++ b/IFilterTextReader/Job.cs
@@ -54,9 +54,15 @@ namespace IFilterTextReader
             var length = Marshal.SizeOf(typeof(NativeMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
             var extendedInfoPtr = Marshal.AllocHGlobal(length);
             Marshal.StructureToPtr(extendedInfo, extendedInfoPtr, false);
-
-            if (!NativeMethods.SetInformationJobObject(_jobHandle, NativeMethods.JobObjectInfoType.ExtendedLimitInformation, extendedInfoPtr, (uint)length))
-                throw new Exception($"Unable to set information.  Error: {Marshal.GetLastWin32Error()}");
+            try
+            {
+                if (!NativeMethods.SetInformationJobObject(_jobHandle, NativeMethods.JobObjectInfoType.ExtendedLimitInformation, extendedInfoPtr, (uint)length))
+                    throw new Exception($"Unable to set information.  Error: {Marshal.GetLastWin32Error()}");
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(extendedInfoPtr);
+            }
         }
         #endregion
 

--- a/IFilterTextReader/NativeMethods.cs
+++ b/IFilterTextReader/NativeMethods.cs
@@ -846,6 +846,9 @@ namespace IFilterTextReader
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern IntPtr LoadLibrary(string lpFileName);
 
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern IntPtr GetModuleHandle(string lpFileName);
+
         [DllImport("propsys.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern uint PSGetNameFromPropertyKey(ref PROPERTYKEY propkey, [Out, MarshalAs(UnmanagedType.LPWStr)] out string ppszCanonicalName);
 


### PR DESCRIPTION
This pull request is aimed to fix native resource leaks and improve filter DLL loading and unloading.

It also serves as a baseline for a workaround to _Foxit PDF iFilter_ bug. Unlike any other iFilters, _Foxit PDF iFilter_ crashes application on shutdown if DLL unload (FreeLibrary call) is performed in a different thread - not the one where this DLL was loaded (LoadLibrary call). Threading model STA or MTA doesn't really matters. You can easily replicate this issue using IFilterTextViewer project. When you close the app, .NET runtime unloads libraries / calls finalizers in background thread which we cannot control. In fact, a finalizer was missing in `ComHelpers` class, so I added it to make things a little bit more predictable. I also added a new method `FilterLoader.Clear` which allows to properly dispose ComHelpers manually - it can be easily invoked via reflection before shutdown to prevent the crash.