### PR TITLE
Don't try to load non-existing dll

### DIFF
--- a/IFilterTextReader/ComHelpers.cs
+++ b/IFilterTextReader/ComHelpers.cs
@@ -68,6 +68,10 @@ namespace IFilterTextReader
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.Synchronized)]
         private NativeMethods.IClassFactory GetClassFactoryFromDll(string dllName, string filterPersistClass)
         {
+            // Don't try to load non-existing dll
+            if (dllName == null || filterPersistClass == null)
+                return null;
+
             // Load the dll if it is not already loaded
             var dllHandle = NativeMethods.GetModuleHandle(dllName);
             if (dllHandle == IntPtr.Zero)


### PR DESCRIPTION
Fix for a regression issue introduced in #52.
For non-registered iFilter (when GetFilterDllAndClass is unable to find a persistent handler and therefore dllName and filterPersistClass become null) we accidentally get "Could not get proc address from filter dll" exception instead of "There is no NN bits IFilter installed for the extension 'ext'".

@Sicos2002, I would be grateful if you could merge this PR and build a new nuget package v1.7.9.1 and delete v1.7.9.
Thank you!